### PR TITLE
Store Start Token Position in S-Expression Metadata

### DIFF
--- a/src/clj_antlr/coerce.clj
+++ b/src/clj_antlr/coerce.clj
@@ -34,6 +34,14 @@
                {:error (c/recognition-exception->map e)})
     node))
 
+(defn- attach-positional-metadata
+  [^ParserRuleContext t sexpr]
+  (let [^Token start-token (.getStart t)]
+    (->> {:clj-antlr/position
+          {:row    (dec (.getLine start-token))
+           :column (.getCharPositionInLine start-token)
+           :index  (.getStartIndex start-token)}}
+         (with-meta sexpr))))
 
 (defn- literal->sexpr
   [^ParseTree t]
@@ -43,7 +51,8 @@
   (if (instance? ParserRuleContext t)
     (->> (mapv #(sexpr % p) (c/children t))
          (cons (sexpr-head t p))
-         (maybe-error-node t))
+         (maybe-error-node t)
+         (attach-positional-metadata t))
     (literal->sexpr t)))
 
 (defn tokens->sexpr


### PR DESCRIPTION
This PR adjusts the coercer to attach positional information about the first token of a subtree to the metadata of the coerced s-expression (using the key `:clj-antlr/position`) This addresses #1.

Let me know if you prefer a different approach. It's thinkable, for example, to only activate this if the `:format` option is set to e.g. `:sexpr-with-metadata`; or to introduce an additional option like `:track-position?`.
