### PR TITLE
Update antlr to 4.7.2, switching from deprecated AntlrInputStream

### DIFF
--- a/grammars/Json.g4
+++ b/grammars/Json.g4
@@ -109,7 +109,7 @@ HEX_DIGIT
 
 fragment
 ESC_SEQ
-  : '\\' ('\"'|'\\'|'/'|'b'|'f'|'n'|'r'|'t')
+  : '\\' ('"'|'\\'|'/'|'b'|'f'|'n'|'r'|'t')
   | UNICODE_ESC
 ;
 

--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.antlr/antlr4-runtime "4.5.3"]
-                 [org.antlr/antlr4 "4.5.3"]]
+                 [org.antlr/antlr4-runtime "4.7.2"]
+                 [org.antlr/antlr4 "4.7.2"]]
   :profiles {:dev {:dependencies
-                   [[criterium "0.4.4"]
-                    [cheshire "5.6.3"]
+                   [[criterium "0.4.5"]
+                    [cheshire "5.8.1"]
                     [org.clojure/test.check "0.9.0"]
-                    [instaparse "1.4.2"]]}}
+                    [instaparse "1.4.10"]]}}
   :java-source-paths ["src/java/"]
   :test-selectors {:default (complement :perf)
                    :perf :perf

--- a/src/clj_antlr/static.clj
+++ b/src/clj_antlr/static.clj
@@ -19,7 +19,7 @@
 (defmacro lexer
     "Given a lexer class, returns a lexer over a string or stream."
     [lexer-class s]
-    `(new ~lexer-class (input-stream ~s)))
+    `(new ~lexer-class (char-stream ~s)))
 
 (defn signature
   "The signature of a reflected method."

--- a/src/java/CaseChangingCharStream.java
+++ b/src/java/CaseChangingCharStream.java
@@ -1,0 +1,110 @@
+/*
+ * [The "BSD 3-clause license"]
+ * Copyright (c) 2012-2017 The ANTLR Project. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.antlr.v4.runtime;
+
+import org.antlr.v4.runtime.misc.Interval;
+
+/**
+ * This class supports case-insensitive lexing by wrapping an existing
+ * {@link CharStream} and forcing the lexer to see either upper or
+ * lowercase characters. Grammar literals should then be either upper or
+ * lower case such as 'BEGIN' or 'begin'. The text of the character
+ * stream is unaffected. Example: input 'BeGiN' would match lexer rule
+ * 'BEGIN' if constructor parameter upper=true but getText() would return
+ * 'BeGiN'.
+ */
+public class CaseChangingCharStream implements CharStream {
+
+	final CharStream stream;
+	final boolean upper;
+
+	/**
+	 * Constructs a new CaseChangingCharStream wrapping the given {@link CharStream} forcing
+	 * all characters to upper case or lower case.
+	 * @param stream The stream to wrap.
+	 * @param upper If true force each symbol to upper case, otherwise force to lower.
+	 */
+	public CaseChangingCharStream(CharStream stream, boolean upper) {
+		this.stream = stream;
+		this.upper = upper;
+	}
+
+	@Override
+	public String getText(Interval interval) {
+		return stream.getText(interval);
+	}
+
+	@Override
+	public void consume() {
+		stream.consume();
+	}
+
+	@Override
+	public int LA(int i) {
+		int c = stream.LA(i);
+		if (c <= 0) {
+			return c;
+		}
+		if (upper) {
+			return Character.toUpperCase(c);
+		}
+		return Character.toLowerCase(c);
+	}
+
+	@Override
+	public int mark() {
+		return stream.mark();
+	}
+
+	@Override
+	public void release(int marker) {
+		stream.release(marker);
+	}
+
+	@Override
+	public int index() {
+		return stream.index();
+	}
+
+	@Override
+	public void seek(int index) {
+		stream.seek(index);
+	}
+
+	@Override
+	public int size() {
+		return stream.size();
+	}
+
+	@Override
+	public String getSourceName() {
+		return stream.getSourceName();
+	}
+}


### PR DESCRIPTION
`AntlrInputStream` has been deprecated in favor of `CharStream` in antlr 4.7, which also changes the [process needed to get case insensitivity](https://github.com/antlr/antlr4/blob/master/doc/case-insensitive-lexing.md).

 While the library's overall functionality switches to use the new char-streams in this PR, for now this leaves `antlr-input-stream`, `input-stream`, and `case-sensitive-input-stream` in place in `clj-antlr.common` with docstring notes added about deprecation, and leaves `CaseInsensitiveInputStream.java` present as well, though java compilation gets a deprecation warning on that file.  

The antlr javadocs do note [the following](https://www.antlr.org/api/Java/org/antlr/v4/runtime/CharStreams.html): "WARNING: If you use both the deprecated and the new streams, you will see a nontrivial performance degradation." For this reason, it might be worth considering removing the functions mentioned above so that users don't end up using them unnecessarily.