### PR TITLE
Remove an overly eager deprecation notice

### DIFF
--- a/src/clj_antlr/common.clj
+++ b/src/clj_antlr/common.clj
@@ -49,7 +49,6 @@
   A let expression which expands into multiple type-hinted bodies with runtime
   type dispatch provided by instanceof. Thanks to amalloy, as usual!"
   [[name expr classes] & body]
-  (log/warn "multi-hinted-let is deprecated and will be removed in a future clj-antlr release. Migrate to char-stream functionality.")
   (let [x (gensym)]
     `(let [~x ~expr]
        (condp instance? ~x


### PR DESCRIPTION
Sorry for not realizing this until after the release (only just now noticing when trying to use the new release as a dependency) -- warning on this macro means that a warning is always cast on ns load, whether or not the macro is actually used. Leaving the notice in the docstring alone should otherwise be sufficient.