### PR TITLE
Align docstring with code

### DIFF
--- a/src/clj_antlr/core.clj
+++ b/src/clj_antlr/core.clj
@@ -48,9 +48,9 @@
   "Constructs a new parser. Takes a filename for an Antlr v4 grammar. Options:
 
   :format           The parse tree to generate. One of:
-                      :sexpr (default)  Nested lists, node names first
-                      :raw              Equivalent to identity
-                      <any function>    Takes a map of {:tree, :parser, etc}
+                      :sexp (default)  Nested lists, node names first
+                      :raw             Equivalent to identity
+                      <any function>   Takes a map of {:tree, :parser, etc}
 
   :root             The string name of the rule to begin parsing. Defaults to
                     the first rule in the grammar.


### PR DESCRIPTION
I was setting `:format` to `:sexpr` as per the doc-string, but my parser wasn't matching any string. This documentation fix now corresponds with the code at line 24.