### PR TITLE
Update antlr to 4.8 and upgrade dev dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,13 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.antlr/antlr4-runtime "4.7.2"]
-                 [org.antlr/antlr4 "4.7.2"]
-                 [org.clojure/tools.logging "0.5.0"]]
+                 [org.antlr/antlr4-runtime "4.8-1"]
+                 [org.antlr/antlr4 "4.8-1"]
+                 [org.clojure/tools.logging "1.1.0"]]
   :profiles {:dev {:dependencies
-                   [[criterium "0.4.5"]
-                    [cheshire "5.9.0"]
-                    [org.clojure/test.check "0.10.0"]
+                   [[criterium "0.4.6"]
+                    [cheshire "5.10.0"]
+                    [org.clojure/test.check "1.1.0"]
                     [instaparse "1.4.10"]]}}
   :java-source-paths ["src/java/"]
   :test-selectors {:default (complement :perf)


### PR DESCRIPTION
Before cutting a new release (#14), it might be worth bumping antlr to 4.8. No new major functionality, but just keeping up.