### PR TITLE
Bump ANTLR to to 4.9.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.antlr/antlr4-runtime "4.8-1"]
-                 [org.antlr/antlr4 "4.8-1"]
+                 [org.antlr/antlr4-runtime "4.9.2"]
+                 [org.antlr/antlr4 "4.9.2"]
                  [org.clojure/tools.logging "1.1.0"]]
   :profiles {:dev {:dependencies
                    [[criterium "0.4.6"]


### PR DESCRIPTION
This changes an error I'm having parsing a protobuf file w/ the `antlr/grammars-v4` protobuf3 grammar from an internal exception about a null field, to a `ParseError`, which is progress.  All the tests still pass.  I'll try to come up with a failing test for my particular case.