### PR TITLE
Update to antlr 4.9.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.antlr/antlr4-runtime "4.9.2"]
-                 [org.antlr/antlr4 "4.9.2"]
+                 [org.antlr/antlr4-runtime "4.9.3"]
+                 [org.antlr/antlr4 "4.9.3"]
                  [org.clojure/tools.logging "1.1.0"]]
   :profiles {:dev {:dependencies
                    [[criterium "0.4.6"]


### PR DESCRIPTION
In particular, it updates icu4j to version 69.1 that fixes [CVE-2020-21913](https://nvd.nist.gov/vuln/detail/CVE-2020-21913).

It was discoverd by via [nvd-clojure](https://github.com/rm-hull/nvd-clojure) while working on a project.