### PR TITLE
Update to antlr4-4.13.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [org.antlr/antlr4-runtime "4.9.3"]
-                 [org.antlr/antlr4 "4.9.3"]
+                 [org.antlr/antlr4-runtime "4.13.2"]
+                 [org.antlr/antlr4 "4.13.2"]
                  [org.clojure/tools.logging "1.2.4"]]
   :profiles {:dev {:dependencies
                    [[criterium "0.4.6"]


### PR DESCRIPTION
This is to make the runtime compatible with newer ATN versions: https://github.com/antlr/antlr4/releases/tag/4.10#:~:text=4.10%2Dgenerated%20parsers%20incompatible%20with%20previous%20runtimes